### PR TITLE
chore(contributors): add missing parentheses for Singleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "contributors": [
     "Andres Escobar <Andres.Escobar@aexp.com> (https://github.com/anescobar1991)",
-    "James Singleton <James.Singleton1@aexp.com> https://github.com/JamesSingleton)",
+    "James Singleton <James.Singleton1@aexp.com> (https://github.com/JamesSingleton)",
     "Jimmy King  <Jimmy.King@aexp.com> (https://github.com/10xLaCroixDrinker)",
     "Jonathan Adshead <Jonathan.Adshead@aexp.com> (https://github.com/JAdshead)",
     "Michael Tobia <Michael.M.Tobia@aexp.com> (https://github.com/Francois-Esquire)",


### PR DESCRIPTION
Adding missing `(` for my github URL